### PR TITLE
update number of post in principal page

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -8,7 +8,7 @@
     "logoDark": "/logoDark.png",
     "lang": "en",
     "description": "Usach Premium es una comunidad creada por y para los estudiantes de primer año de la Universidad de Santiago con el fin de ayudarles en el inicio de esta nueva etapa. Información-Ayudantías-Material de Estudio",
-    "pageSize": 6
+    "pageSize": 100
   },
   "features": {
     "youtube": true,

--- a/src/layouts/Posts.astro
+++ b/src/layouts/Posts.astro
@@ -86,7 +86,7 @@ const totemPage = {
 
   {/* Luego renderizamos los posts normales */}
   {
-    posts?.slice(0, config.site.pageSize).map((post: PostType) => (
+    posts?.map((post: PostType) => (
       <article class="flex w-full flex-col items-start">
         <div class="rounded-lg block overflow-hidden mb-4">
           {post.data.heroImage && (


### PR DESCRIPTION
se actualiza la cantidad de post en la pagina principal para que se muestren hasta 100 post y no sea necesario presionar directamente mostrar todos los post para verlos